### PR TITLE
Changed "home-icon-name" key default to "Home"

### DIFF
--- a/libnautilus-private/org.gnome.nautilus.gschema.xml.in
+++ b/libnautilus-private/org.gnome.nautilus.gschema.xml.in
@@ -267,7 +267,7 @@
       <_description>If this is set to true, an icon linking to the Network Servers view will be put on the desktop.</_description>
     </key>
     <key name="home-icon-name" type="s">
-      <default>''</default>
+      <default l10n="messages" context="home-icon-name">'Home'</default>
       <_summary>Desktop home icon name</_summary>
       <_description>This name can be set if you want a custom name for the home icon on the desktop.</_description>
     </key>


### PR DESCRIPTION
Modified "home-icon-name" so that the home folder is displayed as "Home" when displayed on the desktop (in Classic mode or when turned on using Tweak Tool). Currently, the text for the home folder is "home" with a lowercase h, but "Trash" and "Network Servers" start with capital letters. This change makes the home folder consistent with the other desktop icons.