### PR TITLE
Do not touch the NautilusView model

### DIFF
--- a/src/nautilus-canvas-view.c
+++ b/src/nautilus-canvas-view.c
@@ -1933,8 +1933,6 @@ nautilus_canvas_view_init (NautilusCanvasView *canvas_view)
 	NautilusCanvasContainer *canvas_container;
   	GActionGroup *view_action_group;
 
-        g_return_if_fail (gtk_bin_get_child (GTK_BIN (canvas_view)) == NULL);
-
 	canvas_view->details = g_new0 (NautilusCanvasViewDetails, 1);
 	canvas_view->details->sort = &sort_criteria[0];
 

--- a/src/nautilus-query-editor.c
+++ b/src/nautilus-query-editor.c
@@ -903,7 +903,7 @@ entry_key_press_event_cb (GtkWidget           *widget,
 			  NautilusQueryEditor *editor)
 {
 	if (event->keyval == GDK_KEY_Down) {
-		nautilus_window_grab_focus (NAUTILUS_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (widget))));
+		gtk_widget_grab_focus (gtk_widget_get_toplevel (GTK_WIDGET (widget)));
 	}
 	return FALSE;
 }

--- a/src/nautilus-toolbar.c
+++ b/src/nautilus-toolbar.c
@@ -426,13 +426,7 @@ static void
 view_menu_popover_closed (GtkPopover *popover,
 			  NautilusToolbar *self)
 {
-	NautilusWindowSlot *slot;
-	NautilusView *view;
-
-	slot = nautilus_window_get_active_slot (self->priv->window);
-	view = nautilus_window_slot_get_current_view (slot);
-
-	nautilus_view_grab_focus (view);
+        gtk_widget_grab_focus (GTK_WIDGET (self->priv->window));
 }
 
 static gboolean

--- a/src/nautilus-view.c
+++ b/src/nautilus-view.c
@@ -2293,6 +2293,11 @@ nautilus_view_set_show_hidden_files (NautilusView *view,
 
 	if (show_hidden != view->details->show_hidden_files) {
 		view->details->show_hidden_files = show_hidden;
+
+                g_settings_set_boolean (gtk_filechooser_preferences,
+                                        NAUTILUS_PREFERENCES_SHOW_HIDDEN_FILES,
+                                        show_hidden);
+
 		if (view->details->model != NULL) {
 			load_directory (view, view->details->model);
 		}
@@ -2314,9 +2319,6 @@ action_show_hidden_files (GSimpleAction *action,
 
 	nautilus_view_set_show_hidden_files (view, show_hidden);
 
-        g_settings_set_boolean (gtk_filechooser_preferences,
-                                NAUTILUS_PREFERENCES_SHOW_HIDDEN_FILES,
-                                show_hidden);
 	g_simple_action_set_state (action, state);
 }
 

--- a/src/nautilus-view.c
+++ b/src/nautilus-view.c
@@ -2726,12 +2726,18 @@ slot_inactive (NautilusWindowSlot *slot,
 	remove_update_context_menus_timeout_callback (view);
 }
 
-void
-nautilus_view_grab_focus (NautilusView *view)
+static void
+nautilus_view_grab_focus (GtkWidget *widget)
 {
 	/* focus the child of the scrolled window if it exists */
+        NautilusView *view;
 	GtkWidget *child;
+
+        view = NAUTILUS_VIEW (widget);
 	child = gtk_bin_get_child (GTK_BIN (view->details->scrolled_window));
+
+        GTK_WIDGET_CLASS (nautilus_view_parent_class)->grab_focus (widget);
+
 	if (child) {
 		gtk_widget_grab_focus (GTK_WIDGET (child));
 	}
@@ -7783,6 +7789,7 @@ nautilus_view_class_init (NautilusViewClass *klass)
 	widget_class->destroy = nautilus_view_destroy;
 	widget_class->scroll_event = nautilus_view_scroll_event;
 	widget_class->parent_set = nautilus_view_parent_set;
+        widget_class->grab_focus = nautilus_view_grab_focus;
 
         container_class->add = nautilus_view_container_add;
 

--- a/src/nautilus-view.h
+++ b/src/nautilus-view.h
@@ -380,7 +380,6 @@ gboolean          nautilus_view_can_zoom_out               (NautilusView      *v
 void              nautilus_view_pop_up_pathbar_context_menu (NautilusView    *view,
 							     GdkEventButton  *event,
 							     const char      *location);
-void              nautilus_view_grab_focus                 (NautilusView      *view);
 void              nautilus_view_update_menus               (NautilusView      *view);
 
 void              nautilus_view_update_context_menus       (NautilusView      *view);

--- a/src/nautilus-view.h
+++ b/src/nautilus-view.h
@@ -62,13 +62,13 @@ typedef struct NautilusViewClass NautilusViewClass;
 typedef struct NautilusViewDetails NautilusViewDetails;
 
 struct NautilusView {
-	GtkScrolledWindow parent;
+	GtkOverlay parent;
 
 	NautilusViewDetails *details;
 };
 
 struct NautilusViewClass {
-	GtkScrolledWindowClass parent_class;
+	GtkOverlayClass parent_class;
 
 	/* The 'clear' signal is emitted to empty the view of its contents.
 	 * It must be replaced by each subclass.
@@ -391,5 +391,6 @@ void		  nautilus_view_action_show_hidden_files   (NautilusView      *view,
 							    gboolean           show_hidden);
 
 GActionGroup *    nautilus_view_get_action_group           (NautilusView      *view);
+gboolean          nautilus_view_is_search_directory        (NautilusView      *view);
 
 #endif /* NAUTILUS_VIEW_H */

--- a/src/nautilus-window-slot.c
+++ b/src/nautilus-window-slot.c
@@ -27,7 +27,6 @@
 #include "nautilus-application.h"
 #include "nautilus-canvas-view.h"
 #include "nautilus-desktop-window.h"
-#include "nautilus-floating-bar.h"
 #include "nautilus-list-view.h"
 #include "nautilus-special-location-bar.h"
 #include "nautilus-trash-bar.h"
@@ -61,12 +60,6 @@ enum {
 
 struct NautilusWindowSlotDetails {
 	NautilusWindow *window;
-
-	/* floating bar */
-	guint set_status_timeout_id;
-	guint loading_timeout_id;
-	GtkWidget *floating_bar;
-	GtkWidget *view_overlay;
 
 	/* slot contains
 	 *  1) an vbox containing extra_location_widgets
@@ -131,12 +124,10 @@ static void location_has_really_changed (NautilusWindowSlot *slot);
 static void nautilus_window_slot_connect_new_content_view (NautilusWindowSlot *slot);
 static void nautilus_window_slot_disconnect_content_view (NautilusWindowSlot *slot);
 static void nautilus_window_slot_emit_location_change (NautilusWindowSlot *slot, GFile *from, GFile *to);
-static void setup_loading_floating_bar (NautilusWindowSlot *slot);
 
 static void
 nautilus_window_slot_sync_search_widgets (NautilusWindowSlot *slot)
 {
-	NautilusDirectory *directory;
 	gboolean toggle;
 
 	if (slot != nautilus_window_get_active_slot (slot->details->window)) {
@@ -146,8 +137,7 @@ nautilus_window_slot_sync_search_widgets (NautilusWindowSlot *slot)
 	toggle = slot->details->search_visible;
 
 	if (slot->details->content_view != NULL) {
-		directory = nautilus_view_get_model (slot->details->content_view);
-		if (NAUTILUS_IS_SEARCH_DIRECTORY (directory)) {
+		if (nautilus_view_is_search_directory (slot->details->content_view)) {
 			toggle = TRUE;
 		}
 	}
@@ -187,49 +177,6 @@ nautilus_window_slot_sync_view_mode (NautilusWindowSlot *slot)
 	} else {
 		g_simple_action_set_enabled (G_SIMPLE_ACTION (action), FALSE);
 	}
-}
-
-static void
-remove_loading_floating_bar (NautilusWindowSlot *slot)
-{
-	if (slot->details->loading_timeout_id != 0) {
-		g_source_remove (slot->details->loading_timeout_id);
-		slot->details->loading_timeout_id = 0;
-	}
-
-	gtk_widget_hide (slot->details->floating_bar);
-	nautilus_floating_bar_cleanup_actions (NAUTILUS_FLOATING_BAR (slot->details->floating_bar));
-}
-
-static void
-nautilus_window_slot_on_done_loading (NautilusDirectory  *directory,
-                                      NautilusWindowSlot *slot)
-{
-
-        remove_loading_floating_bar (slot);
-        nautilus_window_slot_set_allow_stop (slot, FALSE);
-}
-
-static void
-connect_directory_signals (NautilusWindowSlot *slot,
-                           NautilusDirectory  *directory)
-{
-        if (NAUTILUS_IS_SEARCH_DIRECTORY (directory)) {
-                g_signal_connect_object (directory, "done-loading",
-                                         G_CALLBACK (nautilus_window_slot_on_done_loading),
-                                         slot, 0);
-        }
-}
-
-static void
-disconnect_directory_signals (NautilusWindowSlot *slot,
-                              NautilusDirectory  *directory)
-{
-        if (NAUTILUS_IS_SEARCH_DIRECTORY (directory)) {
-                g_signal_handlers_disconnect_by_func (directory,
-                                                      G_CALLBACK (nautilus_window_slot_on_done_loading),
-                                                      slot);
-        }
 }
 
 static void
@@ -526,16 +473,6 @@ real_inactive (NautilusWindowSlot *slot)
 }
 
 static void
-floating_bar_action_cb (NautilusFloatingBar *floating_bar,
-			gint action,
-			NautilusWindowSlot *slot)
-{
-	if (action == NAUTILUS_FLOATING_BAR_ACTION_ID_STOP) {
-		nautilus_window_slot_stop_loading (slot);
-	}
-}
-
-static void
 remove_all_extra_location_widgets (GtkWidget *widget,
 				   gpointer data)
 {
@@ -626,22 +563,6 @@ nautilus_window_slot_constructed (GObject *object)
 			   GTK_WIDGET (slot->details->query_editor));
 	gtk_widget_show_all (slot->details->query_editor_revealer);
 	nautilus_window_slot_add_extra_location_widget (slot, slot->details->query_editor_revealer);
-
-	slot->details->view_overlay = gtk_overlay_new ();
-	gtk_widget_add_events (slot->details->view_overlay,
-			       GDK_ENTER_NOTIFY_MASK |
-			       GDK_LEAVE_NOTIFY_MASK);
-	gtk_box_pack_start (GTK_BOX (slot), slot->details->view_overlay, TRUE, TRUE, 0);
-	gtk_widget_show (slot->details->view_overlay);
-
-	slot->details->floating_bar = nautilus_floating_bar_new (NULL, NULL, FALSE);
-	gtk_widget_set_halign (slot->details->floating_bar, GTK_ALIGN_END);
-	gtk_widget_set_valign (slot->details->floating_bar, GTK_ALIGN_END);
-	gtk_overlay_add_overlay (GTK_OVERLAY (slot->details->view_overlay),
-				 slot->details->floating_bar);
-
-	g_signal_connect (slot->details->floating_bar, "action",
-			  G_CALLBACK (floating_bar_action_cb), slot);
 
 	slot->details->title = g_strdup (_("Loading…"));
 }
@@ -889,7 +810,6 @@ begin_location_change (NautilusWindowSlot *slot,
 		       NautilusWindowGoToCallback callback,
 		       gpointer user_data)
 {
-	NautilusDirectory *previous_directory;
         NautilusDirectory *directory;
         NautilusFile *file;
 	gboolean force_reload;
@@ -905,12 +825,8 @@ begin_location_change (NautilusWindowSlot *slot,
 
 	nautilus_profile_start (NULL);
 
-	previous_directory = nautilus_directory_get (previous_location);
         directory = nautilus_directory_get (location);
 
-	/* Disconnect search signals from the old directory if it was a search directory */
-        disconnect_directory_signals (slot, previous_directory);
-	nautilus_directory_unref (previous_directory);
 
         /* Avoid to update status from the current view in our async calls */
         nautilus_window_slot_disconnect_content_view (slot);
@@ -945,7 +861,6 @@ begin_location_change (NautilusWindowSlot *slot,
 	end_location_change (slot);
 
 	nautilus_window_slot_set_allow_stop (slot, TRUE);
-	nautilus_window_slot_set_status (slot, NULL, NULL);
 
 	g_assert (slot->details->pending_location == NULL);
 	g_assert (slot->details->pending_selection == NULL);
@@ -1466,10 +1381,6 @@ create_content_view (NautilusWindowSlot *slot,
 	old_directory = nautilus_directory_get (old_location);
 	new_directory = nautilus_directory_get (slot->details->pending_location);
 
-        /* Connect to the done loading signal if it is a search directory to update
-         * the no results widget */
-        connect_directory_signals (slot, new_directory);
-
 	if (NAUTILUS_IS_SEARCH_DIRECTORY (new_directory) &&
 	    !NAUTILUS_IS_SEARCH_DIRECTORY (old_directory)) {
 		nautilus_search_directory_set_base_model (NAUTILUS_SEARCH_DIRECTORY (new_directory), old_directory);
@@ -1629,7 +1540,6 @@ cancel_location_change (NautilusWindowSlot *slot)
 	location = nautilus_window_slot_get_location (slot);
 
 	directory = nautilus_directory_get (slot->details->location);
-        disconnect_directory_signals (slot, directory);
         /* Stops current loading or search if any, so we are not slow */
 	nautilus_view_stop_loading (slot->details->content_view);
         nautilus_directory_unref (directory);
@@ -2237,70 +2147,7 @@ view_end_loading_cb (NautilusView       *view,
 		slot->details->needs_reload = FALSE;
 	}
 
-        /* If it is a search directory, it will hide the toolbar when the search engine
-         * finishes, not every time the view end loading the new files */
-        if (!NAUTILUS_IS_SEARCH_DIRECTORY (nautilus_view_get_model (slot->details->content_view))) {
-                remove_loading_floating_bar (slot);
-                nautilus_window_slot_set_allow_stop (slot, FALSE);
-        }
-}
-
-static void
-real_setup_loading_floating_bar (NautilusWindowSlot *slot)
-{
-	gboolean disable_chrome;
-
-	g_object_get (nautilus_window_slot_get_window (slot),
-		      "disable-chrome", &disable_chrome,
-		      NULL);
-
-	if (disable_chrome) {
-		gtk_widget_hide (slot->details->floating_bar);
-		return;
-	}
-
-	nautilus_floating_bar_cleanup_actions (NAUTILUS_FLOATING_BAR (slot->details->floating_bar));
-	nautilus_floating_bar_set_primary_label (NAUTILUS_FLOATING_BAR (slot->details->floating_bar),
-						 NAUTILUS_IS_SEARCH_DIRECTORY (nautilus_view_get_model (slot->details->content_view)) ?
-						 _("Searching…") : _("Loading…"));
-	nautilus_floating_bar_set_details_label (NAUTILUS_FLOATING_BAR (slot->details->floating_bar), NULL);
-	nautilus_floating_bar_set_show_spinner (NAUTILUS_FLOATING_BAR (slot->details->floating_bar),
-						slot->details->allow_stop);
-	nautilus_floating_bar_add_action (NAUTILUS_FLOATING_BAR (slot->details->floating_bar),
-					  "process-stop-symbolic",
-					  NAUTILUS_FLOATING_BAR_ACTION_ID_STOP);
-
-	gtk_widget_set_halign (slot->details->floating_bar, GTK_ALIGN_END);
-	gtk_widget_show (slot->details->floating_bar);
-}
-
-static gboolean
-setup_loading_floating_bar_timeout_cb (gpointer user_data)
-{
-	NautilusWindowSlot *slot = user_data;
-
-	slot->details->loading_timeout_id = 0;
-	real_setup_loading_floating_bar (slot);
-
-	return FALSE;
-}
-
-static void
-setup_loading_floating_bar (NautilusWindowSlot *slot)
-{
-	/* setup loading overlay */
-	if (slot->details->set_status_timeout_id != 0) {
-		g_source_remove (slot->details->set_status_timeout_id);
-		slot->details->set_status_timeout_id = 0;
-	}
-
-	if (slot->details->loading_timeout_id != 0) {
-		g_source_remove (slot->details->loading_timeout_id);
-		slot->details->loading_timeout_id = 0;
-	}
-
-	slot->details->loading_timeout_id =
-		g_timeout_add (500, setup_loading_floating_bar_timeout_cb, slot);
+        nautilus_window_slot_set_allow_stop (slot, FALSE);
 }
 
 static void
@@ -2315,9 +2162,7 @@ view_begin_loading_cb (NautilusView       *view,
 		nautilus_window_slot_set_allow_stop (slot, TRUE);
 	}
 
-        setup_loading_floating_bar (slot);
-
-	nautilus_profile_end (NULL);
+        nautilus_profile_end (NULL);
 }
 
 static void
@@ -2422,7 +2267,8 @@ nautilus_window_slot_switch_new_content_view (NautilusWindowSlot *slot)
 		slot->details->new_content_view = NULL;
 
 		widget = GTK_WIDGET (slot->details->content_view);
-		gtk_container_add (GTK_CONTAINER (slot->details->view_overlay), widget);
+		gtk_container_add (GTK_CONTAINER (slot), widget);
+                gtk_widget_set_vexpand (widget, TRUE);
 		gtk_widget_show (widget);
 	}
 }
@@ -2476,7 +2322,6 @@ static void
 nautilus_window_slot_dispose (GObject *object)
 {
 	NautilusWindowSlot *slot;
-	NautilusDirectory *directory;
 	GtkWidget *widget;
 
 	slot = NAUTILUS_WINDOW_SLOT (object);
@@ -2500,16 +2345,6 @@ nautilus_window_slot_dispose (GObject *object)
 		slot->details->new_content_view = NULL;
 	}
 
-	if (slot->details->set_status_timeout_id != 0) {
-		g_source_remove (slot->details->set_status_timeout_id);
-		slot->details->set_status_timeout_id = 0;
-	}
-
-	if (slot->details->loading_timeout_id != 0) {
-		g_source_remove (slot->details->loading_timeout_id);
-		slot->details->loading_timeout_id = 0;
-	}
-
 	nautilus_window_slot_set_viewed_file (slot, NULL);
 	/* TODO? why do we unref here? the file is NULL.
 	 * It was already here before the slot move, though */
@@ -2519,10 +2354,6 @@ nautilus_window_slot_dispose (GObject *object)
 		/* TODO? why do we ref here, instead of unreffing?
 		 * It was already here before the slot migration, though */
 		g_object_ref (slot->details->location);
-
-		directory = nautilus_directory_get (slot->details->location);
-                disconnect_directory_signals (slot, directory);
-                g_object_unref (directory);
 	}
 
         if (slot->details->view_mode_before_search) {
@@ -2715,111 +2546,7 @@ nautilus_window_slot_set_allow_stop (NautilusWindowSlot *slot,
 void
 nautilus_window_slot_stop_loading (NautilusWindowSlot *slot)
 {
-        remove_loading_floating_bar (slot);
         cancel_location_change (slot);
-}
-
-static void
-real_slot_set_short_status (NautilusWindowSlot *slot,
-			    const gchar *primary_status,
-			    const gchar *detail_status)
-{
-	gboolean disable_chrome;
-
-	nautilus_floating_bar_cleanup_actions (NAUTILUS_FLOATING_BAR (slot->details->floating_bar));
-	nautilus_floating_bar_set_show_spinner (NAUTILUS_FLOATING_BAR (slot->details->floating_bar),
-						slot->details->allow_stop);
-
-	g_object_get (nautilus_window_slot_get_window (slot),
-		      "disable-chrome", &disable_chrome,
-		      NULL);
-
-	if ((primary_status == NULL && detail_status == NULL) || disable_chrome) {
-		gtk_widget_hide (slot->details->floating_bar);
-		return;
-	}
-
-	nautilus_floating_bar_set_labels (NAUTILUS_FLOATING_BAR (slot->details->floating_bar),
-					  primary_status, detail_status);
-	gtk_widget_show (slot->details->floating_bar);
-}
-
-typedef struct {
-	gchar *primary_status;
-	gchar *detail_status;
-	NautilusWindowSlot *slot;
-} SetStatusData;
-
-static void
-set_status_data_free (gpointer data)
-{
-	SetStatusData *status_data = data;
-
-	g_free (status_data->primary_status);
-	g_free (status_data->detail_status);
-
-	g_slice_free (SetStatusData, data);
-}
-
-static gboolean
-set_status_timeout_cb (gpointer data)
-{
-	SetStatusData *status_data = data;
-
-	status_data->slot->details->set_status_timeout_id = 0;
-	real_slot_set_short_status (status_data->slot,
-				    status_data->primary_status,
-				    status_data->detail_status);
-
-	return FALSE;
-}
-
-static void
-set_floating_bar_status (NautilusWindowSlot *slot,
-			 const gchar *primary_status,
-			 const gchar *detail_status)
-{
-	GtkSettings *settings;
-	gint double_click_time;
-	SetStatusData *status_data;
-
-	if (slot->details->set_status_timeout_id != 0) {
-		g_source_remove (slot->details->set_status_timeout_id);
-		slot->details->set_status_timeout_id = 0;
-	}
-
-	settings = gtk_settings_get_for_screen (gtk_widget_get_screen (GTK_WIDGET (slot->details->content_view)));
-	g_object_get (settings,
-		      "gtk-double-click-time", &double_click_time,
-		      NULL);
-
-	status_data = g_slice_new0 (SetStatusData);
-	status_data->primary_status = g_strdup (primary_status);
-	status_data->detail_status = g_strdup (detail_status);
-	status_data->slot = slot;
-
-	/* waiting for half of the double-click-time before setting
-	 * the status seems to be a good approximation of not setting it
-	 * too often and not delaying the statusbar too much.
-	 */
-	slot->details->set_status_timeout_id =
-		g_timeout_add_full (G_PRIORITY_DEFAULT,
-				    (guint) (double_click_time / 2),
-				    set_status_timeout_cb,
-				    status_data,
-				    set_status_data_free);
-}
-
-void
-nautilus_window_slot_set_status (NautilusWindowSlot *slot,
-				 const char *primary_status,
-				 const char *detail_status)
-{
-	g_assert (NAUTILUS_IS_WINDOW_SLOT (slot));
-
-	if (slot->details->content_view != NULL) {
-		set_floating_bar_status (slot, primary_status, detail_status);
-	}
 }
 
 /* returns either the pending or the actual current uri */
@@ -2851,7 +2578,7 @@ nautilus_window_slot_get_current_view (NautilusWindowSlot *slot)
 void
 nautilus_window_slot_go_home (NautilusWindowSlot *slot,
 			      NautilusWindowOpenFlags flags)
-{			      
+{
 	GFile *home;
 
 	g_return_if_fail (NAUTILUS_IS_WINDOW_SLOT (slot));

--- a/src/nautilus-window-slot.c
+++ b/src/nautilus-window-slot.c
@@ -392,7 +392,7 @@ nautilus_window_slot_set_search_visible (NautilusWindowSlot *slot,
 		}
 
 		if (active_slot) {
-			nautilus_window_grab_focus (slot->details->window);
+			gtk_widget_grab_focus (GTK_WIDGET (slot->details->window));
 		}
 
 		/* Now hide the editor and clear its state */
@@ -2383,9 +2383,28 @@ nautilus_window_slot_dispose (GObject *object)
 }
 
 static void
+nautilus_window_slot_grab_focus (GtkWidget *widget)
+{
+        NautilusWindowSlot *slot;
+
+        slot = NAUTILUS_WINDOW_SLOT (widget);
+
+        GTK_WIDGET_CLASS (nautilus_window_slot_parent_class)->grab_focus (widget);
+
+        if (slot->details->search_visible) {
+                gtk_widget_grab_focus (GTK_WIDGET (slot->details->query_editor));
+        } else if (slot->details->content_view) {
+                gtk_widget_grab_focus (GTK_WIDGET (slot->details->content_view));
+        } else if (slot->details->new_content_view) {
+                gtk_widget_grab_focus (GTK_WIDGET (slot->details->new_content_view));
+        }
+}
+
+static void
 nautilus_window_slot_class_init (NautilusWindowSlotClass *klass)
 {
 	GObjectClass *oclass = G_OBJECT_CLASS (klass);
+        GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
 	klass->active = real_active;
 	klass->inactive = real_inactive;
@@ -2394,6 +2413,8 @@ nautilus_window_slot_class_init (NautilusWindowSlotClass *klass)
 	oclass->constructed = nautilus_window_slot_constructed;
 	oclass->set_property = nautilus_window_slot_set_property;
 	oclass->get_property = nautilus_window_slot_get_property;
+
+        widget_class->grab_focus = nautilus_window_slot_grab_focus;
 
 	signals[ACTIVE] =
 		g_signal_new ("active",

--- a/src/nautilus-window-slot.h
+++ b/src/nautilus-window-slot.h
@@ -120,9 +120,6 @@ void    nautilus_window_slot_go_home			   (NautilusWindowSlot *slot,
 void    nautilus_window_slot_go_up                         (NautilusWindowSlot *slot,
 							    NautilusWindowOpenFlags flags);
 
-void    nautilus_window_slot_set_status			   (NautilusWindowSlot *slot,
-							    const char         *primary_status,
-							    const char         *detail_status);
 void nautilus_window_slot_sync_view_mode (NautilusWindowSlot *slot);
 
 void nautilus_window_slot_display_view_selection_failure   (NautilusWindow *window,

--- a/src/nautilus-window.c
+++ b/src/nautilus-window.c
@@ -590,17 +590,17 @@ remember_focus_widget (NautilusWindow *window)
 	}
 }
 
-void
-nautilus_window_grab_focus (NautilusWindow *window)
+static void
+nautilus_window_grab_focus (GtkWidget *widget)
 {
 	NautilusWindowSlot *slot;
-	NautilusView *view;
 
-	slot = nautilus_window_get_active_slot (window);
-	view = nautilus_window_slot_get_view (slot);
+	slot = nautilus_window_get_active_slot (NAUTILUS_WINDOW (widget));
 
-	if (view) {
-		nautilus_view_grab_focus (view);
+        GTK_WIDGET_CLASS (nautilus_window_parent_class)->grab_focus (widget);
+
+	if (slot) {
+		gtk_widget_grab_focus (GTK_WIDGET (slot));
 	}
 }
 
@@ -608,12 +608,7 @@ static void
 restore_focus_widget (NautilusWindow *window)
 {
 	if (window->priv->last_focus_widget != NULL) {
-		if (NAUTILUS_IS_VIEW (window->priv->last_focus_widget)) {
-			nautilus_view_grab_focus (NAUTILUS_VIEW (window->priv->last_focus_widget));
-		} else {
-			gtk_widget_grab_focus (window->priv->last_focus_widget);
-		}
-
+		gtk_widget_grab_focus (window->priv->last_focus_widget);
 		unset_focus_widget (window);
 	}
 }
@@ -2285,7 +2280,7 @@ nautilus_window_view_visible (NautilusWindow *window,
 		nautilus_window_slot_update_title (slot);
 	}
 
-	nautilus_window_grab_focus (window);
+	gtk_widget_grab_focus (GTK_WIDGET (window));
 
 	/* All slots, show window */
 	gtk_widget_show (GTK_WIDGET (window));
@@ -2623,6 +2618,7 @@ nautilus_window_class_init (NautilusWindowClass *class)
 	wclass->window_state_event = nautilus_window_state_event;
 	wclass->button_press_event = nautilus_window_button_press_event;
 	wclass->delete_event = nautilus_window_delete_event;
+        wclass->grab_focus = nautilus_window_grab_focus;
 
 	class->close = real_window_close;
 

--- a/src/nautilus-window.c
+++ b/src/nautilus-window.c
@@ -2253,27 +2253,6 @@ nautilus_window_view_visible (NautilusWindow *window,
 
 	g_return_if_fail (NAUTILUS_IS_WINDOW (window));
 
-	/* FIXME: this code is odd and should not really be needed, but
-	 * removing it causes bugs, see e.g.
-	 * https://bugzilla.gnome.org/show_bug.cgi?id=679640
-	 *
-	 * Needs more investigation...
-	 */
-	slot = nautilus_view_get_nautilus_window_slot (view);
-	if (g_object_get_data (G_OBJECT (slot), "nautilus-window-view-visible") != NULL) {
-		return;
-	}
-
-	g_object_set_data (G_OBJECT (slot), "nautilus-window-view-visible", GINT_TO_POINTER (1));
-
-	/* Look for other non-visible slots */
-	for (l = window->priv->slots; l != NULL; l = l->next) {
-		slot = l->data;
-		if (g_object_get_data (G_OBJECT (slot), "nautilus-window-view-visible") == NULL) {
-			return;
-		}
-	}
-
 	/* Look for other non-visible slots */
 	for (l = window->priv->slots; l != NULL; l = l->next) {
 		slot = l->data;

--- a/src/nautilus-window.h
+++ b/src/nautilus-window.h
@@ -122,7 +122,6 @@ void                 nautilus_window_slot_close            (NautilusWindow *wind
                                                             NautilusWindowSlot *slot);
 
 void                 nautilus_window_sync_location_widgets (NautilusWindow *window);
-void                 nautilus_window_grab_focus            (NautilusWindow *window);
 
 void     nautilus_window_hide_sidebar         (NautilusWindow *window);
 void     nautilus_window_show_sidebar         (NautilusWindow *window);


### PR DESCRIPTION
The changes introduced here are meant to reduce the ammount of code coupling between the classes. The main change here is that no other classes access the view's model anymore.
