### PR TITLE
Canva/grid view background fix

### DIFF
--- a/src/nautilus-files-view.c
+++ b/src/nautilus-files-view.c
@@ -8298,6 +8298,7 @@ nautilus_files_view_new (guint                id,
         switch (id) {
         case NAUTILUS_VIEW_GRID_ID:
                 view = nautilus_canvas_view_new (slot);
+                gtk_style_context_add_class (gtk_widget_get_style_context (view), GTK_STYLE_CLASS_VIEW);
         break;
         case NAUTILUS_VIEW_LIST_ID:
                 view = nautilus_list_view_new (slot);

--- a/src/resources/css/Adwaita.css
+++ b/src/resources/css/Adwaita.css
@@ -1,8 +1,3 @@
-.nautilus-window,
-.nautilus-window notebook,
-.nautilus-window notebook > stack {
-    background: white;
-}
 
 .nautilus-canvas-item {
     border-radius: 5px;


### PR DESCRIPTION
Fix the background for the grid view in all themes, and without changing the appearance of extra space left over list view scrollbars when users disable overlay scrolling.  This is an alternative to just-committed:

https://github.com/lukefromdc/nautilus/commit/b71b236b9ef6fb7793658ce0e669b2631efcca17

and is theme independent. Tested in Adwaita, several MATE themes and in my own custom theme with my normal workaround for https://bugzilla.gnome.org/show_bug.cgi?id=761965 disabled

This works by setting the .view style class on the scrolledwindow containing the canvas view. Since this is behind a case switch it is easily applied to only the grid view without affecting the desktop or the list view.  Modified from:

https://github.com/mate-desktop/caja/commit/e5c29655e5301b6d4ba19a3d4970745804039c0e
