### PR TITLE
Fixed limit name displayed last row of file/folder

### DIFF
--- a/src/nautilus-canvas-container.c
+++ b/src/nautilus-canvas-container.c
@@ -1322,7 +1322,7 @@ lay_down_icons_horizontal (NautilusCanvasContainer *container,
         /* Advance to the baseline. */
         y += ICON_PAD_TOP + max_height_above;
 
-        lay_down_one_line (container, line_start, NULL, y, max_height_above, positions, TRUE);
+        lay_down_one_line (container, line_start, NULL, y, max_height_above, positions, FALSE);
     }
 
     g_array_free (positions, TRUE);


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/nautilus/-/merge_requests/406/diffs Changed TRUE to FALSE in lay_down_one_line in line 1283 to fix the limit of the name displayed in the last row of file/folder