### PR TITLE
[REVERT] window: Parse toast title as plain text

### DIFF
--- a/src/nautilus-window.c
+++ b/src/nautilus-window.c
@@ -1365,8 +1365,7 @@ nautilus_window_show_operation_notification (NautilusWindow *window,
 
     toast = adw_toast_new (main_label);
     adw_toast_set_priority (toast, ADW_TOAST_PRIORITY_HIGH);
-    adw_toast_set_use_markup (toast, FALSE);
-
+    
     current_location = nautilus_window_slot_get_location (window->active_slot);
     if (!g_file_equal (folder_to_open, current_location))
     {


### PR DESCRIPTION
[REVERT] window: Parse toast title as plain text

Pango markup is enabled by default for the AdwToast title for operation
notifications. This means symbols like "&" cause issues. So let's
disable the markup on the toast altogether.

Fixes https://gitlab.gnome.org/GNOME/nautilus/-/issues/3085


(cherry picked from commit 7094e2f3d7f252b00b1f9b1cce2347dd16573c63)